### PR TITLE
fix for deprecated "postgres://..." issue in heroku

### DIFF
--- a/shortener_app/database.py
+++ b/shortener_app/database.py
@@ -8,7 +8,7 @@ import os
 
 DATABASE_URL = os.environ['DATABASE_URL']
 if DATABASE_URL and DATABASE_URL.startswith("postgres/"):
-    DATABASE_URL = DATABASE_URL.replace("postgres://","postgresql://",1)
+    DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql://", 1)
 
 conn = psycopg2.connect(DATABASE_URL,sslmode='require')
 


### PR DESCRIPTION
https://stackoverflow.com/questions/62688256/sqlalchemy-exc-nosuchmoduleerror-cant-load-plugin-sqlalchemy-dialectspostgre